### PR TITLE
fixed appearance of several regs and wires so that they are defined b…

### DIFF
--- a/hdl/jt49_cen.v
+++ b/hdl/jt49_cen.v
@@ -30,6 +30,9 @@ module jt49_cen(
     output  reg cen256
 );
 
+wire toggle16 = sel ? !cencnt[CLKDIV-1:0] : !cencnt[CLKDIV:0];
+wire toggle256= sel ? !cencnt[eg-2:0]     : !cencnt[eg-1:0];
+
 reg [9:0] cencnt;
 parameter CLKDIV = 3; // use 3 for standalone JT49 or 2
 localparam eg = CLKDIV; //8;
@@ -46,9 +49,6 @@ always @(negedge clk) begin
     cen16  <= cen & toggle16;
     cen256 <= cen & toggle256;
 end
-
-wire toggle16 = sel ? !cencnt[CLKDIV-1:0] : !cencnt[CLKDIV:0];
-wire toggle256= sel ? !cencnt[eg-2:0]     : !cencnt[eg-1:0];
 
 
 endmodule // jt49_cen

--- a/hdl/jt49_eg.v
+++ b/hdl/jt49_eg.v
@@ -45,8 +45,8 @@ wire will_hold = !CONT || HOLD;
 always @(posedge clk)
     if( cen ) env <= inv ? ~gain : gain;
 
-wire step_edge = (step && !last_step) || null_period;
 reg  last_step;
+wire step_edge = (step && !last_step) || null_period;
 wire will_invert = (!CONT&&ATT) || (CONT&&ALT);
 
 always @( posedge clk, negedge rst_n )


### PR DESCRIPTION
Here I fix the definition of 'last_step' in jt49_eg.v and definitions of 'toggle16' and 'toggle256' in jt49_cen.v so that they become defined before they are used elsewhere.

Without this fix, modelsim was giving compile errors.
