### PR TITLE
Export PIO output enables

### DIFF
--- a/hdl/jt49.v
+++ b/hdl/jt49.v
@@ -39,9 +39,11 @@ module jt49 ( // note that input ports are not multiplexed
 
     input      [7:0] IOA_in,
     output     [7:0] IOA_out,
+    output           IOA_oe,
 
     input      [7:0] IOB_in,
-    output     [7:0] IOB_out
+    output     [7:0] IOB_out,
+    output           IOB_oe
 );
 
 parameter [1:0] COMP=2'b00;
@@ -60,8 +62,10 @@ wire cen16, cen256;
 
 assign IOA_out = regarray[14];
 assign IOB_out = regarray[15];
-assign port_A  = !regarray[7][6] ? IOA_in : IOA_out;
-assign port_B  = !regarray[7][7] ? IOB_in : IOB_out;
+assign port_A  = IOA_in;
+assign port_B  = IOB_in;
+assign IOA_oe  = regarray[7][6];
+assign IOB_oe  = regarray[7][7];
 assign sample  = cen16;
 
 jt49_cen #(.CLKDIV(CLKDIV)) u_cen(

--- a/hdl/jt49_bus.v
+++ b/hdl/jt49_bus.v
@@ -42,9 +42,11 @@ module jt49_bus ( // note that input ports are not multiplexed
 
     input      [7:0] IOA_in,
     output     [7:0] IOA_out,
+    output           IOA_oe,
 
     input      [7:0] IOB_in,
-    output     [7:0] IOB_out
+    output     [7:0] IOB_out,
+    output           IOB_oe
 );
 
 parameter [1:0] COMP=2'b00;
@@ -94,8 +96,10 @@ jt49 #(.COMP(COMP)) u_jt49( // note that input ports are not multiplexed
     .C      (  C         ),
     .IOA_in (  IOA_in    ),
     .IOA_out(  IOA_out   ),
+    .IOA_oe (  IOA_oe    ),
     .IOB_in (  IOB_in    ),
-    .IOB_out(  IOB_out   )
+    .IOB_out(  IOB_out   ),
+    .IOB_oe (  IOB_oe    )
 );
 
 endmodule // jt49_bus


### PR DESCRIPTION
OE signals can be used to determine if the ports are in high impedance state.
Also remove the logic which automatically feeds back the output register to input when the port is set to output, as it's possible to 'override' the input even if the direction is output.

Feedback can be applied externally if desired, like:
IOx_in = IOx_oe ? IOx_out : port_input